### PR TITLE
Remove dtrace-provider dependency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+# Version 0.0.3 11/26/17
+
+- Remove dtrace-provider functionality and dependency.
+
 # Version 0.0.1, 2/8/16
 
 - Forked from https://github.com/joyent/node-snmpjs

--- a/docs/agent.restdown
+++ b/docs/agent.restdown
@@ -18,7 +18,6 @@ optional, contains any or all of the following members:
 
 	{
 		name: [String],
-		dtrace: [Object (DTraceProvider)],
 		log: [Object (bunyan)]
 	}
 
@@ -26,14 +25,8 @@ The interfaces provided by the Agent object are described in detail below.
 
 ### name
 
-If present, the `name` member will be used to name the DTrace provider and to
-decorate log output.  The default value is `'snmpjs'`.
-
-### dtrace
-
-If present, the agent's DTrace probes will be appended to the existing provider
-referenced by the `dtrace` member.  Otherwise, a new provider identified by the
-`name` member (or its default value if absent) will be created.
+If present, the `name` member will be used to decorate log output. The default
+value is `'snmpjs'`.
 
 ### log
 

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -91,20 +91,6 @@ Agent(options)
 
 	Listener.call(this, options);
 
-	if (typeof (options.dtrace) !== 'object')
-		throw new TypeError('options.dtrace (object) is required');
-
-	this._dtrace = options.dtrace;
-
-	Object.keys(AGENT_PROBES).forEach(function (p) {
-		var args = AGENT_PROBES[p].splice(0);
-		args.unshift(p);
-
-		self._dtrace.addProbe.apply(self._dtrace, args);
-	});
-
-	this._dtrace.enable();
-
 	this._mib = new MIB();
 }
 util.inherits(Agent, Listener);

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,6 @@
  * http://www.snmp.com/protocol/snmp_rfcs.shtml as a starting point.
  */
 
-var dtrace = require('dtrace-provider');
 var Agent = require('./agent');
 var Client = require('./client');
 var TrapListener = require('./trap_listener');
@@ -44,15 +43,6 @@ bunyan_serialize_endpoint(endpoint)
 }
 
 function
-defaultDTrace(name)
-{
-	if (!agent_provider)
-		agent_provider = dtrace.createDTraceProvider(name);
-
-	return (agent_provider);
-}
-
-function
 defaultLogger(log, name)
 {
 	var serializers = {
@@ -84,8 +74,6 @@ module.exports = {
 			options = {};
 		if (!options.name)
 			options.name = 'snmpjs';
-		if (!options.dtrace)
-			options.dtrace = defaultDTrace(options.name);
 
 		options.log = defaultLogger(options.log, options.name);
 

--- a/lib/protocol/message.js
+++ b/lib/protocol/message.js
@@ -253,7 +253,7 @@ bunyan_serialize_snmpmsg(snmpmsg)
 			oid: snmpmsg.pdu.varbinds[i].oid,
 			typename: snmpmsg.pdu.varbinds[i].data.typename,
 			value: dv,
-			string_value: dv.toString()
+			string_value: dv ? dv.toString() : ''
 		};
 		obj.pdu.varbinds.push(vb);
 	}

--- a/package.json
+++ b/package.json
@@ -2,23 +2,22 @@
 	"author": "Dan Griscom <griscom@suitable.com>",
 	"name": "snmpjs-new",
 	"description": "Simple Network Management Protocol toolkit",
-	"version": "0.0.2",
+	"version": "0.0.3",
 	"repository": {
 		"type": "git",
 		"url": "git://github.com/dtgriscom/node-snmpjs-new.git"
 	},
 	"bugs": {
-		"url" : "http://github.com/dtgriscom/node-snmpjs-new/issues"
+		"url": "http://github.com/dtgriscom/node-snmpjs-new/issues"
 	},
 	"main": "lib/index.js",
 	"engines": {
 		"node": ">=0.6.9"
 	},
 	"dependencies": {
-		"jison": "0.3",
-		"asn1": "~0.2.2",
-		"bunyan": "~1.8",
-		"dtrace-provider": "~0.8"
+		"asn1": "^0.2.3",
+		"bunyan": "^1.8.12",
+		"jison": "0.3"
 	},
 	"devDependencies": {
 		"tap": "~0.4"


### PR DESCRIPTION
It seems that while dtrace-provider probes were being created, they weren't useful because there was no code to actually fire the probes. This introduced an unnecessary binary dependency to this module.

This patch removes the (as far as I can tell) useless dtrace-provider stuff.

Though bunyan still has an optional dependency on dtrace-provider, this can be circumvented by installing with `npm install --no-optional`.